### PR TITLE
Build against Nix master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,4 @@ jobs:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v12
     #- run: nix flake check
-    - run: nix-build -A checks.x86_64-linux.build
-  #validate-openapi:
-  #  runs-on: ubuntu-18.04
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #    with:
-  #      fetch-depth: 0
-  #  - uses: cachix/install-nix-action@v12
-  #  - run: nix-shell -p openapi-generator-cli --run "openapi-generator-cli validate -i ./hydra-api.yaml"
+    - run: nix-build -A checks.x86_64-linux.build -A checks.x86_64-linux.validate-openapi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     - uses: cachix/install-nix-action@v12
     #- run: nix flake check
     - run: nix-build -A checks.x86_64-linux.build
-  validate-openapi:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: cachix/install-nix-action@v12
-    - run: nix-shell -p openapi-generator-cli --run "openapi-generator-cli validate -i ./hydra-api.yaml"
+  #validate-openapi:
+  #  runs-on: ubuntu-18.04
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #    with:
+  #      fetch-depth: 0
+  #  - uses: cachix/install-nix-action@v12
+  #  - run: nix-shell -p openapi-generator-cli --run "openapi-generator-cli validate -i ./hydra-api.yaml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v12
     #- run: nix flake check
     - run: nix-build -A checks.x86_64-linux.build
   validate-openapi:
@@ -18,5 +18,5 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v12
     - run: nix-shell -p openapi-generator-cli --run "openapi-generator-cli validate -i ./hydra-api.yaml"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ hydra-config.h.in
 result
 tests/jobs/config.nix
 outputs
+config
+stamp-h1
+src/hydra-evaluator/hydra-evaluator
+src/hydra-queue-runner/hydra-queue-runner

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1605715425,
-        "narHash": "sha256-h4VEpxnPBoUigXeoy0/8z8jUFKkJD9XG5dR/lt/rQCk=",
+        "lastModified": 1609520816,
+        "narHash": "sha256-IGO7tfJXsv9u2wpW76VCzOsHYapRZqH9pHGVsoffPrI=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "79aa7d95183cbe6c0d786965f0dbff414fd1aa67",
+        "rev": "8a2ce0f455da32bc20978e68c0aad9efb4560abc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,32 +1,15 @@
 {
   "nodes": {
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1598695561,
-        "narHash": "sha256-gyH/5j+h/nWw0W8AcR2WKvNBUsiQ7QuxqSJNXAwV+8E=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "1705b4a26fbf065d9574dce47a94e8c7c79e052f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1609520816,
-        "narHash": "sha256-IGO7tfJXsv9u2wpW76VCzOsHYapRZqH9pHGVsoffPrI=",
-        "owner": "NixOS",
+        "lastModified": 1614008152,
+        "narHash": "sha256-gHsagqu6UpeltrCFJZqsrdkPH5YWnDIyK/inNPiG3SE=",
+        "owner": "nixos",
         "repo": "nix",
-        "rev": "8a2ce0f455da32bc20978e68c0aad9efb4560abc",
+        "rev": "8043bc6c8d614b074767f875abeff8b5d84da158",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -482,11 +482,19 @@
             '';
           };
 
+        tests.validate-openapi = pkgs.runCommand "validate-openapi"
+          { buildInputs = [ pkgs.openapi-generator-cli ]; }
+          ''
+            openapi-generator-cli validate -i ${./hydra-api.yaml}
+            touch $out
+          '';
+
         container = nixosConfigurations.container.config.system.build.toplevel;
       };
 
       checks.x86_64-linux.build = hydraJobs.build.x86_64-linux;
       checks.x86_64-linux.install = hydraJobs.tests.install.x86_64-linux;
+      checks.x86_64-linux.validate-openapi = hydraJobs.tests.validate-openapi;
 
       packages.x86_64-linux.hydra = pkgs.hydra;
       defaultPackage.x86_64-linux = pkgs.hydra;

--- a/hydra-api.yaml
+++ b/hydra-api.yaml
@@ -384,6 +384,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /job/{project-id}/{jobset-id}/{job-id}/shield:
+    get:
+      summary: Generate data for a shields.io badge
+      parameters:
+      - name: project-id
+        in: path
+        description: project identifier
+        required: true
+        schema:
+          type: string
+      - name: jobset-id
+        in: path
+        description: jobset identifier
+        required: true
+        schema:
+          type: string
+      - name: job-id
+        in: path
+        description: job identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: see <a href="https://shields.io/endpoint">https://shields.io/endpoint</a> on how to use this
+          content:
+            application/json:
+              examples:
+                shield-success:
+                  value:
+                    color: green
+                    schemaVersion: 1
+                    label: hydra build
+                    message: passing
+
   /build/{build-id}:
     get:
       summary: Retrieves a single build of a jobset by id

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -78,12 +78,12 @@ static std::string queryMetaStrings(EvalState & state, DrvInfo & drv, const stri
 
     rec = [&](Value & v) {
         state.forceValue(v);
-        if (v.type == tString)
+        if (v.type() == nString)
             res.push_back(v.string.s);
         else if (v.isList())
             for (unsigned int n = 0; n < v.listSize(); ++n)
                 rec(*v.listElems()[n]);
-        else if (v.type == tAttrs) {
+        else if (v.type() == nAttrs) {
             auto a = v.attrs->find(state.symbols.create(subAttribute));
             if (a != v.attrs->end())
                 res.push_back(state.forceString(*a->value));
@@ -201,7 +201,7 @@ static void worker(
                     for (unsigned int n = 0; n < a->value->listSize(); ++n) {
                         auto v = a->value->listElems()[n];
                         state.forceValue(*v);
-                        if (v->type == tString)
+                        if (v->type() == nString)
                             job["namedConstituents"].push_back(state.forceStringNoCtx(*v));
                     }
                 }
@@ -224,7 +224,7 @@ static void worker(
                 reply["job"] = std::move(job);
             }
 
-            else if (v->type == tAttrs) {
+            else if (v->type() == nAttrs) {
                 auto attrs = nlohmann::json::array();
                 StringSet ss;
                 for (auto & i : v->attrs->lexicographicOrder()) {
@@ -238,7 +238,7 @@ static void worker(
                 reply["attrs"] = std::move(attrs);
             }
 
-            else if (v->type == tNull)
+            else if (v->type() == nNull)
                 ;
 
             else throw TypeError("attribute '%s' is %s, which is not supported", attrPath, showType(*v));

--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
@@ -38,15 +38,6 @@ struct MyArgs : MixEvalArgs, MixCommonArgs
     MyArgs() : MixCommonArgs("hydra-eval-jobs")
     {
         addFlag({
-            .longName = "help",
-            .description = "show usage information",
-            .handler = {[&]() {
-                printHelp(programName, std::cout);
-                throw Exit();
-            }}
-        });
-
-        addFlag({
             .longName = "gc-roots-dir",
             .description = "garbage collector roots directory",
             .labels = {"path"},

--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -68,7 +68,9 @@ struct Evaluator
         pqxx::work txn(*conn);
 
         auto res = txn.exec
-            ("select project, j.name, lastCheckedTime, triggerTime, checkInterval, j.enabled as jobset_enabled from Jobsets j join Projects p on j.project = p.name "
+            ("select project, j.name, lastCheckedTime, triggerTime, checkInterval, j.enabled as jobset_enabled "
+             "from Jobsets j "
+             "join Projects p on j.project = p.name "
              "where j.enabled != 0 and p.enabled != 0");
 
 

--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -13,7 +13,7 @@
 
 using namespace nix;
 
-typedef std::pair<std::string, std::string> JobsetName;
+typedef std::pair<std::string, std::string> JobsetIdentity;
 
 enum class EvaluationStyle
 {
@@ -30,16 +30,16 @@ struct Evaluator
 
     struct Jobset
     {
-        JobsetName name;
+        JobsetIdentity name;
         std::optional<EvaluationStyle> evaluation_style;
         time_t lastCheckedTime, triggerTime;
         int checkInterval;
         Pid pid;
     };
 
-    typedef std::map<JobsetName, Jobset> Jobsets;
+    typedef std::map<JobsetIdentity, Jobset> Jobsets;
 
-    std::optional<JobsetName> evalOne;
+    std::optional<JobsetIdentity> evalOne;
 
     const size_t maxEvals;
 
@@ -76,10 +76,10 @@ struct Evaluator
 
         auto state(state_.lock());
 
-        std::set<JobsetName> seen;
+        std::set<JobsetIdentity> seen;
 
         for (auto const & row : res) {
-            auto name = JobsetName{row["project"].as<std::string>(), row["name"].as<std::string>()};
+            auto name = JobsetIdentity{row["project"].as<std::string>(), row["name"].as<std::string>()};
 
             if (evalOne && name != *evalOne) continue;
 
@@ -466,7 +466,7 @@ int main(int argc, char * * argv)
         else {
             if (!args.empty()) {
                 if (args.size() != 2) throw UsageError("Syntax: hydra-evaluator [<project> <jobset>]");
-                evaluator.evalOne = JobsetName(args[0], args[1]);
+                evaluator.evalOne = JobsetIdentity(args[0], args[1]);
             }
             evaluator.run();
         }

--- a/src/hydra-evaluator/hydra-evaluator.cc
+++ b/src/hydra-evaluator/hydra-evaluator.cc
@@ -13,9 +13,9 @@
 
 using namespace nix;
 
-typedef std::pair<std::string, std::string> JobsetSymbolicIdentity;
+typedef std::pair<std::string, std::string> JobsetName;
 
-class JobsetIdentity {
+class JobsetId {
     public:
 
     std::string project;
@@ -23,44 +23,44 @@ class JobsetIdentity {
     int id;
 
 
-    JobsetIdentity(const std::string& project, const std::string& jobset, const int id)
+    JobsetId(const std::string & project, const std::string & jobset, int id)
         : project{ project }, jobset{ jobset }, id{ id }
     {
     }
 
-    friend bool operator== (const JobsetIdentity &lhs, const JobsetIdentity &rhs);
-    friend bool operator!= (const JobsetIdentity &lhs, const JobsetIdentity &rhs);
-    friend bool operator< (const JobsetIdentity &lhs, const JobsetIdentity &rhs);
+    friend bool operator== (const JobsetId & lhs, const JobsetId & rhs);
+    friend bool operator!= (const JobsetId & lhs, const JobsetId & rhs);
+    friend bool operator< (const JobsetId & lhs, const JobsetId & rhs);
 
 
-    friend bool operator== (const JobsetIdentity &lhs, const JobsetSymbolicIdentity &rhs);
-    friend bool operator!= (const JobsetIdentity &lhs, const JobsetSymbolicIdentity &rhs);
+    friend bool operator== (const JobsetId & lhs, const JobsetName & rhs);
+    friend bool operator!= (const JobsetId & lhs, const JobsetName & rhs);
 
     std::string display() const {
         return str(format("%1%:%2% (jobset#%3%)") % project % jobset % id);
     }
 };
-bool operator==(const JobsetIdentity & lhs, const JobsetIdentity & rhs)
+bool operator==(const JobsetId & lhs, const JobsetId & rhs)
 {
     return lhs.id == rhs.id;
 }
 
-bool operator!=(const JobsetIdentity & lhs, const JobsetIdentity & rhs)
+bool operator!=(const JobsetId & lhs, const JobsetId & rhs)
 {
     return lhs.id != rhs.id;
 }
 
-bool operator<(const JobsetIdentity & lhs, const JobsetIdentity & rhs)
+bool operator<(const JobsetId & lhs, const JobsetId & rhs)
 {
     return lhs.id < rhs.id;
 }
 
-bool operator==(const JobsetIdentity & lhs, const JobsetSymbolicIdentity & rhs)
+bool operator==(const JobsetId & lhs, const JobsetName & rhs)
 {
     return lhs.project == rhs.first && lhs.jobset == rhs.second;
 }
 
-bool operator!=(const JobsetIdentity & lhs, const JobsetSymbolicIdentity & rhs)
+bool operator!=(const JobsetId & lhs, const JobsetName & rhs)
 {
     return ! (lhs == rhs);
 }
@@ -80,16 +80,16 @@ struct Evaluator
 
     struct Jobset
     {
-        JobsetIdentity name;
+        JobsetId name;
         std::optional<EvaluationStyle> evaluation_style;
         time_t lastCheckedTime, triggerTime;
         int checkInterval;
         Pid pid;
     };
 
-    typedef std::map<JobsetIdentity, Jobset> Jobsets;
+    typedef std::map<JobsetId, Jobset> Jobsets;
 
-    std::optional<JobsetSymbolicIdentity> evalOne;
+    std::optional<JobsetName> evalOne;
 
     const size_t maxEvals;
 
@@ -126,10 +126,10 @@ struct Evaluator
 
         auto state(state_.lock());
 
-        std::set<JobsetIdentity> seen;
+        std::set<JobsetId> seen;
 
         for (auto const & row : res) {
-            auto name = JobsetIdentity{row["project"].as<std::string>(), row["name"].as<std::string>(), row["id"].as<int>()};
+            auto name = JobsetId{row["project"].as<std::string>(), row["name"].as<std::string>(), row["id"].as<int>()};
 
             if (evalOne && name != *evalOne) continue;
 
@@ -511,7 +511,7 @@ int main(int argc, char * * argv)
         else {
             if (!args.empty()) {
                 if (args.size() != 2) throw UsageError("Syntax: hydra-evaluator [<project> <jobset>]");
-                evaluator.evalOne = JobsetSymbolicIdentity(args[0], args[1]);
+                evaluator.evalOne = JobsetName(args[0], args[1]);
             }
             evaluator.run();
         }

--- a/src/hydra-queue-runner/hydra-queue-runner.cc
+++ b/src/hydra-queue-runner/hydra-queue-runner.cc
@@ -96,8 +96,10 @@ void State::parseMachines(const std::string & contents)
         machine->sshName = tokens[0];
         machine->systemTypes = tokenizeString<StringSet>(tokens[1], ",");
         machine->sshKey = tokens[2] == "-" ? string("") : tokens[2];
-        if (tokens[3] != "")
-            string2Int(tokens[3], machine->maxJobs);
+        if (tokens[3] != "") {
+          if (auto maxJobs = string2Int<unsigned int>(tokens[3]))
+              machine->maxJobs = *maxJobs;
+        }
         else
             machine->maxJobs = 1;
         machine->speedFactor = atof(tokens[4].c_str());
@@ -862,7 +864,9 @@ int main(int argc, char * * argv)
             else if (*arg == "--status")
                 status = true;
             else if (*arg == "--build-one") {
-                if (!string2Int<BuildID>(getArg(*arg, arg, end), buildOne))
+                if (auto maybeBuildOne = string2Int<BuildID>(getArg(*arg, arg, end)))
+                    buildOne = *maybeBuildOne;
+                else
                     throw Error("‘--build-one’ requires a build ID");
             } else
                 return false;

--- a/src/hydra-queue-runner/nar-extractor.cc
+++ b/src/hydra-queue-runner/nar-extractor.cc
@@ -45,15 +45,15 @@ struct Extractor : ParseSink
         hashSink = std::make_unique<HashSink>(htSHA256);
     }
 
-    void receiveContents(unsigned char * data, size_t len) override
+    void receiveContents(std::string_view data) override
     {
         assert(expectedSize);
         assert(curMember);
         assert(hashSink);
-        *curMember->fileSize += len;
-        (*hashSink)(data, len);
+        *curMember->fileSize += data.size();
+        (*hashSink)(data);
         if (curMember->contents) {
-            curMember->contents->append((char *) data, len);
+            curMember->contents->append(data);
         }
         assert(curMember->fileSize <= expectedSize);
         if (curMember->fileSize == expectedSize) {

--- a/src/lib/Hydra/Controller/API.pm
+++ b/src/lib/Hydra/Controller/API.pm
@@ -265,7 +265,7 @@ sub push_github : Chained('api') PathPart('push-github') Args(0) {
     triggerJobset($self, $c, $_, 0) foreach $c->model('DB::Jobsets')->search(
         { 'project.enabled' => 1, 'me.enabled' => 1 },
         { join => 'project'
-        , where => \ [ 'exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value like ?)', [ 'value', "%github.com%$owner/$repo%" ] ]
+        , where => \ [ 'me.flake like ? or exists (select 1 from JobsetInputAlts where project = me.project and jobset = me.name and value like ?)', [ 'flake', "%github%$owner/$repo%"], [ 'value', "%github.com%$owner/$repo%" ] ]
         });
     $c->response->body("");
 }

--- a/src/lib/Hydra/Controller/Admin.pm
+++ b/src/lib/Hydra/Controller/Admin.pm
@@ -34,7 +34,7 @@ sub machines : Chained('admin') PathPart('machines') Args(0) {
 sub clear_queue_non_current : Chained('admin') PathPart('clear-queue-non-current') Args(0) {
     my ($self, $c) = @_;
     my $builds = $c->model('DB::Builds')->search(
-        { id => { -in => \ "select id from Builds where id in ((select id from Builds where finished = 0) except (select build from JobsetEvalMembers where eval in (select max(id) from JobsetEvals where hasNewBuilds = 1 group by project, jobset)))" }
+        { id => { -in => \ "select id from Builds where id in ((select id from Builds where finished = 0) except (select build from JobsetEvalMembers where eval in (select max(id) from JobsetEvals where hasNewBuilds = 1 group by jobset_id)))" }
         });
     my $n = cancelBuilds($c->model('DB')->schema, $builds);
     $c->flash->{successMsg} = "$n builds have been cancelled.";

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -143,7 +143,7 @@ sub create_jobset : Chained('evalChain') PathPart('create-jobset') Args(0) {
 
 sub cancel : Chained('evalChain') PathPart('cancel') Args(0) {
     my ($self, $c) = @_;
-    requireCancelBuildPrivileges($c, $c->stash->{eval}->project);
+    requireCancelBuildPrivileges($c, $c->stash->{project});
     my $n = cancelBuilds($c->model('DB')->schema, $c->stash->{eval}->builds);
     $c->flash->{successMsg} = "$n builds have been cancelled.";
     $c->res->redirect($c->uri_for($c->controller('JobsetEval')->action_for('view'), $c->req->captures));
@@ -152,7 +152,7 @@ sub cancel : Chained('evalChain') PathPart('cancel') Args(0) {
 
 sub restart {
     my ($self, $c, $condition) = @_;
-    requireRestartPrivileges($c, $c->stash->{eval}->project);
+    requireRestartPrivileges($c, $c->stash->{project});
     my $builds = $c->stash->{eval}->builds->search({ finished => 1, buildstatus => $condition });
     my $n = restartBuilds($c->model('DB')->schema, $builds);
     $c->flash->{successMsg} = "$n builds have been restarted.";
@@ -174,7 +174,7 @@ sub restart_failed : Chained('evalChain') PathPart('restart-failed') Args(0) {
 
 sub bump : Chained('evalChain') PathPart('bump') Args(0) {
     my ($self, $c) = @_;
-    requireBumpPrivileges($c, $c->stash->{eval}->project); # FIXME: require admin?
+    requireBumpPrivileges($c, $c->stash->{project}); # FIXME: require admin?
     my $builds = $c->stash->{eval}->builds->search({ finished => 0 });
     my $n = $builds->count();
     $c->model('DB')->schema->txn_do(sub {

--- a/src/lib/Hydra/Controller/JobsetEval.pm
+++ b/src/lib/Hydra/Controller/JobsetEval.pm
@@ -16,8 +16,8 @@ sub evalChain : Chained('/') PathPart('eval') CaptureArgs(1) {
         or notFound($c, "Evaluation $evalId doesn't exist.");
 
     $c->stash->{eval} = $eval;
-    $c->stash->{project} = $eval->project;
     $c->stash->{jobset} = $eval->jobset;
+    $c->stash->{project} = $eval->jobset->project;
 }
 
 

--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -30,6 +30,8 @@ sub noLoginNeeded {
   return $whitelisted ||
          $c->request->path eq "api/push-github" ||
          $c->request->path eq "google-login" ||
+         $c->request->path eq "github-redirect" ||
+         $c->request->path eq "github-login" ||
          $c->request->path eq "login" ||
          $c->request->path eq "logo" ||
          $c->request->path =~ /^static\//;

--- a/src/lib/Hydra/Controller/Root.pm
+++ b/src/lib/Hydra/Controller/Root.pm
@@ -13,6 +13,7 @@ use Nix::Config;
 use Encode;
 use File::Basename;
 use JSON;
+use List::Util qw[min max];
 use List::MoreUtils qw{any};
 use Net::Prometheus;
 
@@ -438,12 +439,8 @@ sub search :Local Args(0) {
     error($c, "Invalid character in query.")
         unless $query =~ /^[a-zA-Z0-9_\-\/.]+$/;
 
-    my $limit = trim $c->request->params->{"limit"};
-    if ($limit eq "") {
-        $c->stash->{limit} = 500;
-    } else {
-        $c->stash->{limit} = $limit;
-    }
+    my $limit = int(trim ($c->request->params->{"limit"} || "10"));
+    $c->stash->{limit} = min(50, max(1, $limit));
 
     $c->stash->{projects} = [ $c->model('DB::Projects')->search(
         { -and =>

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -189,7 +189,6 @@ sub github_login :Path('/github-login') Args(0) {
 
     foreach my $eml (@{$data}) {
         $email = $eml->{email} if $eml->{verified} && $eml->{primary};
-        print STDERR "$eml->{email}\n";
     }
 
     print STDERR "$email\n";

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -158,7 +158,6 @@ sub google_login :Path('/google-login') Args(0) {
 sub github_login :Path('/github-login') Args(0) {
     my ($self, $c) = @_;
 
-    error($c, "Logging in via GitHub is not enabled.") unless $c->config->{enable_github_login};
     my $client_id = $c->config->{github_client_id} or die "github_client_id not configured.";
     my $client_secret = $c->config->{github_client_secret} // do {
         my $client_secret_file = $c->config->{github_client_secret_file} or die "github_client_secret nor github_client_secret_file is configured.";
@@ -205,7 +204,6 @@ sub github_login :Path('/github-login') Args(0) {
 sub github_redirect :Path('/github-redirect') Args(0) {
     my ($self, $c) = @_;
 
-    error($c, "Logging in via GitHub is not enabled.") unless $c->config->{enable_github_login};
     my $client_id = $c->config->{github_client_id} or die "github_client_id not configured.";
 
     my $after = "/" . $c->req->params->{after};

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -215,7 +215,7 @@ sub github_redirect :Path('/github-redirect') Args(0) {
         value => $after,
     };
 
-    $c->res->redirect("https://github.com/login/oauth/authorize?client_id=$client_id");
+    $c->res->redirect("https://github.com/login/oauth/authorize?client_id=$client_id&scope=user:email");
 }
 
 

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -191,6 +191,8 @@ sub github_login :Path('/github-login') Args(0) {
         $email = $eml->{email} if $eml->{verified} && $eml->{primary};
     }
 
+    die "No primary email for this GitHub profile" unless $email;
+
     $response = $ua->get('https://api.github.com/user', Authorization => "token $access_token");
     error($c, "Did not get a response from GitHub for user info.") unless $response->is_success;
     $data = decode_json($response->decoded_content) or die;

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -4,6 +4,7 @@ use utf8;
 use strict;
 use warnings;
 use base 'Hydra::Base::Controller::REST';
+use File::Slurp;
 use Crypt::RandPasswd;
 use Digest::SHA1 qw(sha1_hex);
 use Hydra::Helper::Nix;
@@ -152,6 +153,57 @@ sub google_login :Path('/google-login') Args(0) {
     # FIXME: verify hosted domain claim?
 
     doEmailLogin($self, $c, "google", $data->{email}, $data->{name} // undef);
+}
+
+sub github_login :Path('/github-login') Args(0) {
+    my ($self, $c) = @_;
+
+    error($c, "Logging in via GitHub is not enabled.") unless $c->config->{enable_github_login};
+    my $client_id = $c->config->{github_client_id} or die "github_client_id not configured.";
+    my $client_secret = $c->config->{github_client_secret} // do {
+        my $client_secret_file = $c->config->{github_client_secret_file} or die "github_client_secret nor github_client_secret_file is configured.";
+        my $client_secret = read_file($client_secret_file);
+        $client_secret =~ s/\s+//;
+        $client_secret;
+    };
+    die "No github secret configured" unless $client_secret;
+
+    my $ua = new LWP::UserAgent;
+    my $response = $ua->post(
+        'https://github.com/login/oauth/access_token',
+        {
+            client_id => $client_id,
+            client_secret => $client_secret,
+            code => ($c->req->params->{code} // die "No token."),
+        }, Accept => 'application/json');
+    error($c, "Did not get a response from GitHub.") unless $response->is_success;
+
+    my $data = decode_json($response->decoded_content) or die;
+    my $access_token = $data->{access_token} // die "No access_token in response from GitHub.";
+
+    $response = $ua->get('https://api.github.com/user', Authorization => "token $access_token");
+    error($c, "Did not get a response from GitHub for user info.") unless $response->is_success;
+
+    $data = decode_json($response->decoded_content) or die;
+    doEmailLogin($self, $c, "github", $data->{email}, $data->{name} // undef);
+
+    $c->res->redirect($c->uri_for($c->res->cookies->{'after_github'}));
+}
+
+sub github_redirect :Path('/github-redirect') Args(0) {
+    my ($self, $c) = @_;
+
+    error($c, "Logging in via GitHub is not enabled.") unless $c->config->{enable_github_login};
+    my $client_id = $c->config->{github_client_id} or die "github_client_id not configured.";
+
+    my $after = "/" . $c->req->params->{after};
+
+    $c->res->cookies->{'after_github'} = {
+        name => 'after_github',
+        value => $after,
+    };
+
+    $c->res->redirect("https://github.com/login/oauth/authorize?client_id=$client_id");
 }
 
 

--- a/src/lib/Hydra/Controller/User.pm
+++ b/src/lib/Hydra/Controller/User.pm
@@ -191,7 +191,6 @@ sub github_login :Path('/github-login') Args(0) {
         $email = $eml->{email} if $eml->{verified} && $eml->{primary};
     }
 
-    print STDERR "$email\n";
     $response = $ua->get('https://api.github.com/user', Authorization => "token $access_token");
     error($c, "Did not get a response from GitHub for user info.") unless $response->is_success;
     $data = decode_json($response->decoded_content) or die;

--- a/src/lib/Hydra/Helper/AddBuilds.pm
+++ b/src/lib/Hydra/Helper/AddBuilds.pm
@@ -49,6 +49,18 @@ sub updateDeclarativeJobset {
         $update{$key} = $declSpec->{$key};
         delete $declSpec->{$key};
     }
+    # Ensure jobset constraints are met, only have nixexpr{path,input} or
+    # flakes set if the type is 0 or 1 respectively. So in the update we need
+    # to null the field of the other type.
+    if (defined $update{type}) {
+        if ($update{type} == 0) {
+            $update{flake} = undef;
+        } elsif ($update{type} == 1) {
+            $update{nixexprpath} = undef;
+            $update{nixexprinput} = undef;
+        }
+    }
+
     $db->txn_do(sub {
         my $jobset = $project->jobsets->update_or_create(\%update);
         $jobset->jobsetinputs->delete;

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -219,7 +219,7 @@ sub getEvals {
     foreach my $curEval (@evals) {
 
         my ($prevEval) = $c->model('DB::JobsetEvals')->search(
-            { project => $curEval->get_column('project'), jobset => $curEval->get_column('jobset')
+            { jobset_id => $curEval->get_column('jobset_id')
             , hasnewbuilds => 1, id => { '<', $curEval->id } },
             { order_by => "id DESC", rows => 1 });
 

--- a/src/lib/Hydra/Helper/Nix.pm
+++ b/src/lib/Hydra/Helper/Nix.pm
@@ -211,8 +211,8 @@ sub getEvals {
 
     my @evals = $evals->search(
         { hasnewbuilds => 1 },
-        { order_by => "id DESC", rows => $rows, offset => $offset });
-
+        { order_by => "me.id DESC", rows => $rows, offset => $offset
+        , prefetch => { evaluationerror => [  ] } });
     my @res = ();
     my $cache = {};
 

--- a/src/lib/Hydra/Schema/Builds.pm
+++ b/src/lib/Hydra/Schema/Builds.pm
@@ -134,16 +134,6 @@ __PACKAGE__->table("builds");
   default_value: 0
   is_nullable: 1
 
-=head2 nixexprinput
-
-  data_type: 'text'
-  is_nullable: 1
-
-=head2 nixexprpath
-
-  data_type: 'text'
-  is_nullable: 1
-
 =head2 priority
 
   data_type: 'integer'
@@ -246,10 +236,6 @@ __PACKAGE__->add_columns(
   { data_type => "integer", default_value => 0, is_nullable => 0 },
   "iscurrent",
   { data_type => "integer", default_value => 0, is_nullable => 1 },
-  "nixexprinput",
-  { data_type => "text", is_nullable => 1 },
-  "nixexprpath",
-  { data_type => "text", is_nullable => 1 },
   "priority",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
   "globalpriority",
@@ -542,8 +528,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-05-27 17:40:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:RIKKFfcKXFWIUeM8ma++iw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Df5N0EByYJqoSUqA0dld/A
 
 __PACKAGE__->has_many(
   "dependents",

--- a/src/lib/Hydra/Schema/EvaluationErrors.pm
+++ b/src/lib/Hydra/Schema/EvaluationErrors.pm
@@ -1,0 +1,108 @@
+use utf8;
+package Hydra::Schema::EvaluationErrors;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Hydra::Schema::EvaluationErrors
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<Hydra::Component::ToJSON>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("+Hydra::Component::ToJSON");
+
+=head1 TABLE: C<evaluationerrors>
+
+=cut
+
+__PACKAGE__->table("evaluationerrors");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'integer'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'evaluationerrors_id_seq'
+
+=head2 errormsg
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 errortime
+
+  data_type: 'integer'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "evaluationerrors_id_seq",
+  },
+  "errormsg",
+  { data_type => "text", is_nullable => 1 },
+  "errortime",
+  { data_type => "integer", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 jobsetevals
+
+Type: has_many
+
+Related object: L<Hydra::Schema::JobsetEvals>
+
+=cut
+
+__PACKAGE__->has_many(
+  "jobsetevals",
+  "Hydra::Schema::JobsetEvals",
+  { "foreign.evaluationerror_id" => "self.id" },
+  undef,
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-02-01 20:17:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sZIg35KWCO8MOsQ5cfN1IA
+
+__PACKAGE__->add_column(
+    "+id" => { retrieve_on_insert => 1 }
+);
+
+1;

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -42,15 +42,9 @@ __PACKAGE__->table("jobsetevals");
   is_nullable: 0
   sequence: 'jobsetevals_id_seq'
 
-=head2 project
+=head2 jobset_id
 
-  data_type: 'text'
-  is_foreign_key: 1
-  is_nullable: 0
-
-=head2 jobset
-
-  data_type: 'text'
+  data_type: 'integer'
   is_foreign_key: 1
   is_nullable: 0
 
@@ -124,10 +118,8 @@ __PACKAGE__->add_columns(
     is_nullable       => 0,
     sequence          => "jobsetevals_id_seq",
   },
-  "project",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
-  "jobset",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "jobset_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "errormsg",
   { data_type => "text", is_nullable => 1 },
   "errortime",
@@ -179,8 +171,8 @@ Related object: L<Hydra::Schema::Jobsets>
 __PACKAGE__->belongs_to(
   "jobset",
   "Hydra::Schema::Jobsets",
-  { name => "jobset", project => "project" },
-  { is_deferrable => 0, on_delete => "CASCADE", on_update => "CASCADE" },
+  { id => "jobset_id" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 jobsetevalinputs
@@ -213,24 +205,9 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 project
 
-Type: belongs_to
-
-Related object: L<Hydra::Schema::Projects>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "project",
-  "Hydra::Schema::Projects",
-  { name => "project" },
-  { is_deferrable => 0, on_delete => "CASCADE", on_update => "CASCADE" },
-);
-
-
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:43:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VKQNG53wwdbO8p1CTdX+WA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:44:07
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OVxeYH+eoZZrAsAJ2/mAAA
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -54,6 +54,16 @@ __PACKAGE__->table("jobsetevals");
   is_foreign_key: 1
   is_nullable: 0
 
+=head2 errormsg
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 errortime
+
+  data_type: 'integer'
+  is_nullable: 1
+
 =head2 timestamp
 
   data_type: 'integer'
@@ -108,6 +118,10 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "jobset",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "errormsg",
+  { data_type => "text", is_nullable => 1 },
+  "errortime",
+  { data_type => "integer", is_nullable => 1 },
   "timestamp",
   { data_type => "integer", is_nullable => 0 },
   "checkouttime",
@@ -201,8 +215,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-05-27 17:40:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:M61ikfnjORU7jDAH8P/j7w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-21 11:13:38
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zDBtAFc4HiFUcL/TpkuCcg
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -89,6 +89,16 @@ __PACKAGE__->table("jobsetevals");
   data_type: 'text'
   is_nullable: 0
 
+=head2 nixexprinput
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 nixexprpath
+
+  data_type: 'text'
+  is_nullable: 1
+
 =head2 nrbuilds
 
   data_type: 'integer'
@@ -132,6 +142,10 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "hash",
   { data_type => "text", is_nullable => 0 },
+  "nixexprinput",
+  { data_type => "text", is_nullable => 1 },
+  "nixexprpath",
+  { data_type => "text", is_nullable => 1 },
   "nrbuilds",
   { data_type => "integer", is_nullable => 1 },
   "nrsucceeded",
@@ -215,8 +229,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-21 11:13:38
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zDBtAFc4HiFUcL/TpkuCcg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hdu+0WWo2363dVvImMKxdA
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -48,14 +48,10 @@ __PACKAGE__->table("jobsetevals");
   is_foreign_key: 1
   is_nullable: 0
 
-=head2 errormsg
-
-  data_type: 'text'
-  is_nullable: 1
-
-=head2 errortime
+=head2 evaluationerror_id
 
   data_type: 'integer'
+  is_foreign_key: 1
   is_nullable: 1
 
 =head2 timestamp
@@ -120,10 +116,8 @@ __PACKAGE__->add_columns(
   },
   "jobset_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
-  "errormsg",
-  { data_type => "text", is_nullable => 1 },
-  "errortime",
-  { data_type => "integer", is_nullable => 1 },
+  "evaluationerror_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "timestamp",
   { data_type => "integer", is_nullable => 0 },
   "checkouttime",
@@ -159,6 +153,26 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
+
+=head2 evaluationerror
+
+Type: belongs_to
+
+Related object: L<Hydra::Schema::EvaluationErrors>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "evaluationerror",
+  "Hydra::Schema::EvaluationErrors",
+  { id => "evaluationerror_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "SET NULL",
+    on_update     => "NO ACTION",
+  },
+);
 
 =head2 jobset
 
@@ -206,8 +220,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:44:07
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OVxeYH+eoZZrAsAJ2/mAAA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-02-01 20:17:39
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SGtK0PwRkbxiMuitQvs4wQ
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/JobsetEvals.pm
+++ b/src/lib/Hydra/Schema/JobsetEvals.pm
@@ -89,16 +89,6 @@ __PACKAGE__->table("jobsetevals");
   data_type: 'text'
   is_nullable: 0
 
-=head2 nixexprinput
-
-  data_type: 'text'
-  is_nullable: 1
-
-=head2 nixexprpath
-
-  data_type: 'text'
-  is_nullable: 1
-
 =head2 nrbuilds
 
   data_type: 'integer'
@@ -110,6 +100,16 @@ __PACKAGE__->table("jobsetevals");
   is_nullable: 1
 
 =head2 flake
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 nixexprinput
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 nixexprpath
 
   data_type: 'text'
   is_nullable: 1
@@ -142,15 +142,15 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_nullable => 0 },
   "hash",
   { data_type => "text", is_nullable => 0 },
-  "nixexprinput",
-  { data_type => "text", is_nullable => 1 },
-  "nixexprpath",
-  { data_type => "text", is_nullable => 1 },
   "nrbuilds",
   { data_type => "integer", is_nullable => 1 },
   "nrsucceeded",
   { data_type => "integer", is_nullable => 1 },
   "flake",
+  { data_type => "text", is_nullable => 1 },
+  "nixexprinput",
+  { data_type => "text", is_nullable => 1 },
+  "nixexprpath",
   { data_type => "text", is_nullable => 1 },
 );
 
@@ -229,8 +229,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hdu+0WWo2363dVvImMKxdA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:43:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VKQNG53wwdbO8p1CTdX+WA
 
 __PACKAGE__->has_many(
   "buildIds",

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -375,8 +375,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-05-27 17:40:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aDW78MCelU/ma953aTcHvA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:6P1qlC5oVSPRSgRBp6nmrw
 
 
 =head2 builds

--- a/src/lib/Hydra/Schema/Jobsets.pm
+++ b/src/lib/Hydra/Schema/Jobsets.pm
@@ -301,10 +301,7 @@ Related object: L<Hydra::Schema::JobsetEvals>
 __PACKAGE__->has_many(
   "jobsetevals",
   "Hydra::Schema::JobsetEvals",
-  {
-    "foreign.jobset"  => "self.name",
-    "foreign.project" => "self.project",
-  },
+  { "foreign.jobset_id" => "self.id" },
   undef,
 );
 
@@ -375,8 +372,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:6P1qlC5oVSPRSgRBp6nmrw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:38:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7XtIqrrGAIvReqly1kapog
 
 
 =head2 builds

--- a/src/lib/Hydra/Schema/Projects.pm
+++ b/src/lib/Hydra/Schema/Projects.pm
@@ -258,8 +258,8 @@ Composing rels: L</projectmembers> -> username
 __PACKAGE__->many_to_many("usernames", "projectmembers", "username");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-05-27 17:40:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iBGJjFWiI9Wy9zwT7xGOEA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Ff5gJejFu+02b0lInobOoQ
 
 my %hint = (
     columns => [

--- a/src/lib/Hydra/Schema/Projects.pm
+++ b/src/lib/Hydra/Schema/Projects.pm
@@ -157,21 +157,6 @@ __PACKAGE__->has_many(
   undef,
 );
 
-=head2 jobsetevals
-
-Type: has_many
-
-Related object: L<Hydra::Schema::JobsetEvals>
-
-=cut
-
-__PACKAGE__->has_many(
-  "jobsetevals",
-  "Hydra::Schema::JobsetEvals",
-  { "foreign.project" => "self.name" },
-  undef,
-);
-
 =head2 jobsetrenames
 
 Type: has_many
@@ -258,8 +243,8 @@ Composing rels: L</projectmembers> -> username
 __PACKAGE__->many_to_many("usernames", "projectmembers", "username");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-22 07:11:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Ff5gJejFu+02b0lInobOoQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-01-25 14:38:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+4yWd9UjCyxxLZYDrVUAxA
 
 my %hint = (
     columns => [

--- a/src/root/build.tt
+++ b/src/root/build.tt
@@ -120,7 +120,7 @@ END;
       <b class="caret"></b>
     </a>
     <ul class="dropdown-menu">
-      [% IF build.nixexprinput || eval.flake %]
+      [% IF eval.nixexprinput || eval.flake %]
         <li><a href="#reproduce" data-toggle="modal">Reproduce locally</a></li>
       [% END %]
       [% IF c.user_exists %]
@@ -346,10 +346,10 @@ END;
           <td>[% build.priority %]</td>
         </tr>
       [% END %]
-      [% IF build.nixexprinput %]
+      [% IF eval.nixexprinput %]
         <tr>
           <th>Nix expression:</th>
-          <td>file <tt>[% HTML.escape(build.nixexprpath) %]</tt> in input <tt>[% HTML.escape(build.nixexprinput) %]</tt></td>
+          <td>file <tt>[% HTML.escape(eval.nixexprpath) %]</tt> in input <tt>[% HTML.escape(eval.nixexprinput) %]</tt></td>
         </tr>
       [% END %]
       <tr>

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -476,6 +476,9 @@ BLOCK renderEvals %]
             ELSE %]
              -
             [% END %]
+            [% IF eval.errormsg %]
+              <span class="label label-warning">Eval Errors</span>
+            [% END %]
           </td>
           <td align='right' class="nowrap">
             <span class="label label-success">[% e.nrSucceeded %]</span>

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -463,7 +463,7 @@ BLOCK renderEvals %]
         <tr>
           <td><a class="row-link" href="[% link %]">[% eval.id %]</a></td>
           [% IF !jobset && !build %]
-            <td>[% INCLUDE renderFullJobsetName project=eval.get_column('project') jobset=eval.get_column('jobset') %]</td>
+            <td>[% INCLUDE renderFullJobsetName project=eval.jobset.project.name jobset=eval.jobset.name %]</td>
           [% END %]
           <td class="nowrap">[% INCLUDE renderRelativeDate timestamp = eval.timestamp %]</td>
           <td>

--- a/src/root/common.tt
+++ b/src/root/common.tt
@@ -476,7 +476,7 @@ BLOCK renderEvals %]
             ELSE %]
              -
             [% END %]
-            [% IF eval.errormsg %]
+            [% IF eval.evaluationerror.errormsg %]
               <span class="label label-warning">Eval Errors</span>
             [% END %]
           </td>

--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -89,7 +89,7 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
   [% END %]
   <li><a href="#tabs-inputs" data-toggle="tab">Inputs</a></li>
 
-  [% IF eval.errormsg %]
+  [% IF eval.evaluationerror.errormsg %]
     <li><a href="#tabs-errors" data-toggle="tab"><span class="text-warning">Evaluation errors</span></a></li>
   [% END %]
 
@@ -108,10 +108,10 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
 
 <div class="tab-content">
 
-  [% IF eval.errormsg %]
+  [% IF eval.evaluationerror.errormsg %]
     <div id="tabs-errors" class="tab-pane">
-      <p>Errors occurred at [% INCLUDE renderDateTime timestamp=(eval.errortime || eval.timestamp) %].</p>
-      <pre class="alert alert-error">[% HTML.escape(eval.errormsg) %]</pre>
+      <p>Errors occurred at [% INCLUDE renderDateTime timestamp=(eval.evaluationerror.errortime || eval.timestamp) %].</p>
+      <pre class="alert alert-error">[% HTML.escape(eval.evaluationerror.errormsg) %]</pre>
     </div>
   [% END %]
 
@@ -172,10 +172,10 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
     [% END %]
   </div>
 
-  [% IF eval.errormsg %]
+  [% IF eval.evaluationerror.errormsg %]
     <div id="tabs-errors" class="tab-pane">
-      <p>Errors occurred at [% INCLUDE renderDateTime timestamp=(eval.errortime || eval.timestamp) %].</p>
-      <pre class="alert alert-error">[% HTML.escape(eval.errormsg) %]</pre>
+      <p>Errors occurred at [% INCLUDE renderDateTime timestamp=(eval.evaluationerror.errortime || eval.timestamp) %].</p>
+      <pre class="alert alert-error">[% HTML.escape(eval.evaluationerror.errormsg) %]</pre>
     </div>
   [% END %]
 </div>

--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -88,6 +88,11 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
     <li><a href="#tabs-unfinished" data-toggle="tab">Queued jobs ([% unfinished.size %])</a></li>
   [% END %]
   <li><a href="#tabs-inputs" data-toggle="tab">Inputs</a></li>
+
+  [% IF eval.errormsg %]
+    <li><a href="#tabs-errors" data-toggle="tab"><span class="text-warning">Evaluation errors</span></a></li>
+  [% END %]
+
 </ul>
 
 [% BLOCK renderSome %]
@@ -167,6 +172,12 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
     [% END %]
   </div>
 
+  [% IF eval.errormsg %]
+    <div id="tabs-errors" class="tab-pane">
+      <p>Errors occurred at [% INCLUDE renderDateTime timestamp=(eval.errortime || eval.timestamp) %].</p>
+      <pre class="alert alert-error">[% HTML.escape(eval.errormsg) %]</pre>
+    </div>
+  [% END %]
 </div>
 
 [% END %]

--- a/src/root/jobset-eval.tt
+++ b/src/root/jobset-eval.tt
@@ -103,6 +103,13 @@ c.uri_for(c.controller('JobsetEval').action_for('view'),
 
 <div class="tab-content">
 
+  [% IF eval.errormsg %]
+    <div id="tabs-errors" class="tab-pane">
+      <p>Errors occurred at [% INCLUDE renderDateTime timestamp=(eval.errortime || eval.timestamp) %].</p>
+      <pre class="alert alert-error">[% HTML.escape(eval.errormsg) %]</pre>
+    </div>
+  [% END %]
+
   <div id="tabs-aborted" class="tab-pane">
     [% INCLUDE renderSome builds=aborted tabname="#tabs-aborted" %]
   </div>

--- a/src/root/reproduce.tt
+++ b/src/root/reproduce.tt
@@ -169,7 +169,7 @@ echo "$0: input ‘[% input.name %]’ has unsupported type ‘[% input.type %]�
 exit 1
 [% END %]
 
-[% IF input.name == build.nixexprinput +%]
+[% IF input.name == eval.nixexprinput +%]
 nixExprInputDir="$inputDir"
 [%+ END %]
 
@@ -197,7 +197,7 @@ args+=(--option extra-binary-caches '[% c.uri_for('/') %]')
 # when evaluating jobs that rely on builtins.currentSystem.
 args+=(--option system x86_64-linux)
 
-args+=("$nixExprInputDir/[% build.nixexprpath %]" -A '[% build.job.name %]')
+args+=("$nixExprInputDir/[% eval.nixexprpath %]" -A '[% build.job.name %]')
 
 if [ -n "$printFlags" ]; then
     first=1

--- a/src/root/topbar.tt
+++ b/src/root/topbar.tt
@@ -136,6 +136,10 @@
         <li><a href="#" id="google-signin">Sign in with Google</a></li>
         <li class="divider"></li>
       [% END %]
+      [% IF c.config.enable_github_login %]
+        <li><a href="/github-redirect?after=[% c.req.path %]">Sign in with GitHub</a></li>
+        <li class="divider"></li>
+      [% END %]
       <li>
         <a href="#hydra-signin" data-toggle="modal">Sign in with a Hydra account</a>
       </li>

--- a/src/root/topbar.tt
+++ b/src/root/topbar.tt
@@ -136,7 +136,7 @@
         <li><a href="#" id="google-signin">Sign in with Google</a></li>
         <li class="divider"></li>
       [% END %]
-      [% IF c.config.enable_github_login %]
+      [% IF c.config.github_client_id %]
         <li><a href="/github-redirect?after=[% c.req.path %]">Sign in with GitHub</a></li>
         <li class="divider"></li>
       [% END %]

--- a/src/script/hydra-create-user
+++ b/src/script/hydra-create-user
@@ -11,7 +11,7 @@ sub showHelp {
     print <<EOF;
 Usage: $0 NAME
   [--rename-from NAME]
-  [--type hydra|google]
+  [--type hydra|google|github]
   [--full-name FULLNAME]
   [--email-address EMAIL-ADDRESS]
   [--password PASSWORD]
@@ -49,8 +49,8 @@ GetOptions("rename-from=s" => \$renameFrom,
 die "$0: one user name required\n" if scalar @ARGV != 1;
 my $userName = $ARGV[0];
 
-die "$0: type must be `hydra' or `google'\n"
-    if defined $type && $type ne "hydra" && $type ne "google";
+die "$0: type must be `hydra', `google' or `github'\n"
+    if defined $type && $type ne "hydra" && $type ne "google" && $type ne "github";
 
 my $db = Hydra::Model::DB->new();
 
@@ -67,19 +67,19 @@ $db->txn_do(sub {
             { username => $userName, type => "hydra", emailaddress => "", password => "!" });
     }
 
-    die "$0: Google user names must be email addresses\n"
-        if $user->type eq "google" && $userName !~ /\@/;
+    die "$0: Google or GitHub user names must be email addresses\n"
+        if ($user->type eq "google" || $user->type eq "github") && $userName !~ /\@/;
 
     $user->update({ type => $type }) if defined $type;
 
     $user->update({ fullname => $fullName eq "" ? undef : $fullName }) if defined $fullName;
 
-    if ($user->type eq "google") {
-        die "$0: Google accounts do not have an explicitly set email address.\n"
+    if ($user->type eq "google" || $user->type eq "github") {
+        die "$0: Google and GitHub accounts do not have an explicitly set email address.\n"
             if defined $emailAddress;
-        die "$0: Google accounts do not have a password.\n"
+        die "$0: Google and GitHub accounts do not have a password.\n"
             if defined $password;
-        die "$0: Google accounts do not have a password.\n"
+        die "$0: Google and GitHub accounts do not have a password.\n"
             if defined $passwordHash;
         $user->update({ emailaddress => $userName, password => "!" });
     } else {

--- a/src/script/hydra-dev-server
+++ b/src/script/hydra-dev-server
@@ -5,6 +5,11 @@ BEGIN {
 }
 
 use Catalyst::ScriptRunner;
+
+STDOUT->autoflush();
+STDERR->autoflush(1);
+binmode STDERR, ":encoding(utf8)";
+
 Catalyst::ScriptRunner->run('Hydra', 'DevServer');
 
 1;

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -191,8 +191,11 @@ sub fetchInputEval {
         $eval = getLatestFinishedEval($jobset);
         die "jobset ‘$value’ does not have a finished evaluation\n" unless defined $eval;
     } elsif ($value =~ /^($projectNameRE):($jobsetNameRE):($jobNameRE)$/) {
+        my $jobset = $db->resultset('Jobsets')->find({ project => $1, name => $2 });
+        die "jobset ‘$1:$2’ does not exist\n" unless defined $jobset;
+
         $eval = $db->resultset('JobsetEvals')->find(
-            { project => $1, jobset => $2, hasnewbuilds => 1 },
+            { jobset_id => $jobset->id, hasnewbuilds => 1 },
             { order_by => "id DESC", rows => 1
             , where =>
                 \ [ # All builds in this jobset should be finished...

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -693,6 +693,12 @@ sub checkJobsetWrapped {
     }
     setJobsetError($jobset, $evaluationErrorMsg, $evaluationErrorTime);
 
+    my $evaluationErrorRecord = $db->resultset('EvaluationErrors')->create(
+        { errormsg => $evaluationErrorMsg
+        , errortime => $evaluationErrorTime
+        }
+    );
+
     my %buildMap;
     $db->txn_do(sub {
 
@@ -715,12 +721,12 @@ sub checkJobsetWrapped {
             (scalar(grep { $_->{new} } values(%buildMap)) > 0)
             || (defined $prevEval && $prevEval->jobsetevalmembers->count != scalar(keys %buildMap));
 
+
         my $ev = $jobset->jobsetevals->create(
             { hash => $argsHash
+            , evaluationerror => $evaluationErrorRecord
             , timestamp => time
             , checkouttime => abs(int($checkoutStop - $checkoutStart))
-            , errormsg => $evaluationErrorMsg
-            , errortime => $evaluationErrorTime
             , evaltime => abs(int($evalStop - $evalStart))
             , hasnewbuilds => $jobsetChanged ? 1 : 0
             , nrbuilds => $jobsetChanged ? scalar(keys %buildMap) : undef

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -460,8 +460,6 @@ sub checkBuild {
             , nixname => $buildInfo->{nixName}
             , drvpath => $drvPath
             , system => $buildInfo->{system}
-            , nixexprinput => $jobset->nixexprinput
-            , nixexprpath => $jobset->nixexprpath
             , priority => $buildInfo->{schedulingPriority}
             , finished => 0
             , iscurrent => 1
@@ -724,6 +722,8 @@ sub checkJobsetWrapped {
             , hasnewbuilds => $jobsetChanged ? 1 : 0
             , nrbuilds => $jobsetChanged ? scalar(keys %buildMap) : undef
             , flake => $flakeRef
+            , nixexprinput => $jobset->nixexprinput
+            , nixexprpath => $jobset->nixexprpath
             });
 
         $db->storage->dbh->do("notify eval_added, ?", undef,

--- a/src/script/hydra-eval-jobset
+++ b/src/script/hydra-eval-jobset
@@ -493,12 +493,12 @@ sub fetchInputs {
 
 
 sub setJobsetError {
-    my ($jobset, $errorMsg) = @_;
+    my ($jobset, $errorMsg, $errorTime) = @_;
     my $prevError = $jobset->errormsg;
 
     eval {
         $db->txn_do(sub {
-            $jobset->update({ errormsg => $errorMsg, errortime => time, fetcherrormsg => undef });
+            $jobset->update({ errormsg => $errorMsg, errortime => $errorTime, fetcherrormsg => undef });
         });
     };
     if (defined $errorMsg && $errorMsg ne ($prevError // "") || $ENV{'HYDRA_MAIL_TEST'}) {
@@ -680,6 +680,18 @@ sub checkJobsetWrapped {
     my $jobsetChanged = 0;
     my $dbStart = clock_gettime(CLOCK_MONOTONIC);
 
+
+    # Store the error messages for jobs that failed to evaluate.
+    my $evaluationErrorTime = time;
+    my $evaluationErrorMsg = "";
+    foreach my $job (values %{$jobs}) {
+        next unless defined $job->{error};
+        $evaluationErrorMsg .=
+            ($job->{jobName} ne "" ? "in job ‘$job->{jobName}’" : "at top-level") .
+            ":\n" . $job->{error} . "\n\n";
+    }
+    setJobsetError($jobset, $evaluationErrorMsg, $evaluationErrorTime);
+
     my %buildMap;
     $db->txn_do(sub {
 
@@ -706,6 +718,8 @@ sub checkJobsetWrapped {
             { hash => $argsHash
             , timestamp => time
             , checkouttime => abs(int($checkoutStop - $checkoutStart))
+            , errormsg => $evaluationErrorMsg
+            , errortime => $evaluationErrorTime
             , evaltime => abs(int($evalStop - $evalStart))
             , hasnewbuilds => $jobsetChanged ? 1 : 0
             , nrbuilds => $jobsetChanged ? scalar(keys %buildMap) : undef
@@ -791,16 +805,6 @@ sub checkJobsetWrapped {
     Net::Statsd::timing("hydra.evaluator.db_time", int(($dbStop - $dbStart) * 1000));
     Net::Statsd::increment("hydra.evaluator.evals");
     Net::Statsd::increment("hydra.evaluator.cached_evals") unless $jobsetChanged;
-
-    # Store the error messages for jobs that failed to evaluate.
-    my $msg = "";
-    foreach my $job (values %{$jobs}) {
-        next unless defined $job->{error};
-        $msg .=
-            ($job->{jobName} ne "" ? "in job ‘$job->{jobName}’" : "at top-level") .
-            ":\n" . $job->{error} . "\n\n";
-    }
-    setJobsetError($jobset, $msg);
 }
 
 
@@ -827,9 +831,10 @@ sub checkJobset {
     my $failed = 0;
     if ($checkError) {
         print STDERR $checkError;
+        my $eventTime = time;
         $db->txn_do(sub {
-            $jobset->update({lastcheckedtime => time});
-            setJobsetError($jobset, $checkError);
+            $jobset->update({lastcheckedtime => $eventTime});
+            setJobsetError($jobset, $checkError, $eventTime);
             $db->storage->dbh->do("notify eval_failed, ?", undef, join('\t', $tmpId));
         }) if !$dryRun;
         $failed = 1;

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -10,7 +10,7 @@ create table Users (
     emailAddress  text not null,
     password      text not null, -- sha256 hash
     emailOnError  integer not null default 0,
-    type          text not null default 'hydra', -- either "hydra" or "google"
+    type          text not null default 'hydra', -- either "hydra", "google" or "github"
     publicDashboard boolean not null default false
 );
 

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -440,9 +440,7 @@ create table SystemTypes (
 
 create table JobsetEvals (
     id            serial primary key not null,
-
-    project       text not null,
-    jobset        text not null,
+    jobset_id     integer not null,
 
     errorMsg      text, -- error output from the evaluator
     errorTime     integer, -- timestamp associated with errorMsg
@@ -473,8 +471,7 @@ create table JobsetEvals (
     nixExprInput  text, -- name of the jobsetInput containing the Nix or Guix expression
     nixExprPath   text, -- relative path of the Nix or Guix expression
 
-    foreign key   (project) references Projects(name) on delete cascade on update cascade,
-    foreign key   (project, jobset) references Jobsets(project, name) on delete cascade on update cascade
+    foreign key   (jobset_id) references Jobsets(id) on delete cascade
 );
 
 
@@ -629,7 +626,8 @@ create index IndexBuildOutputsPath on BuildOutputs using hash(path);
 create index IndexBuildsOnKeep on Builds(keep) where keep = 1;
 
 -- To get the most recent eval for a jobset.
-create index IndexJobsetEvalsOnJobsetId on JobsetEvals(project, jobset, id desc) where hasNewBuilds = 1;
+create index IndexJobsetEvalsOnJobsetId on JobsetEvals(jobset_id, id desc) where hasNewBuilds = 1;
+create index IndexJobsetIdEvals on JobsetEvals(jobset_id) where hasNewBuilds = 1;
 
 create index IndexBuildsOnNotificationPendingSince on Builds(notificationPendingSince) where notificationPendingSince is not null;
 

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -162,13 +162,6 @@ create table Builds (
     isChannel     integer not null default 0, -- meta.isHydraChannel
     isCurrent     integer default 0,
 
-    -- Copy of the nixExprInput/nixExprPath fields of the jobset that
-    -- instantiated this build.  Needed if we want to reproduce this
-    -- build.  FIXME: this should be stored in JobsetEvals, storing it
-    -- here is denormal.
-    nixExprInput  text,
-    nixExprPath   text,
-
     -- Priority within a jobset, set via meta.schedulingPriority.
     priority      integer not null default 0,
 
@@ -466,6 +459,8 @@ create table JobsetEvals (
     nrSucceeded   integer, -- set lazily when all builds are finished
 
     flake         text, -- immutable flake reference
+    nixExprInput  text, -- name of the jobsetInput containing the Nix or Guix expression
+    nixExprPath   text, -- relative path of the Nix or Guix expression
 
     foreign key   (project) references Projects(name) on delete cascade on update cascade,
     foreign key   (project, jobset) references Jobsets(project, name) on delete cascade on update cascade

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -1,3 +1,14 @@
+-- Making a database change:
+--
+-- 1. Update this schema document to match what the end result should be.
+--
+-- 2. Run `make -C src/sql update-dbix hydra-postgresql.sql` in the root
+--    of the project directory, and git add / git commit the changed,
+--    generated files.
+--
+-- 3. Create a migration in this same directory, named `upgrade-N.sql`
+--
+
 -- Singleton table to keep track of the schema version.
 create table SchemaVersion (
     version       integer not null

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -437,13 +437,17 @@ create table SystemTypes (
     maxConcurrent integer not null default 2
 );
 
+create table EvaluationErrors (
+    id            serial primary key not null,
+    errorMsg      text,    -- error output from the evaluator
+    errorTime     integer  -- timestamp associated with errorMsg
+);
 
 create table JobsetEvals (
     id            serial primary key not null,
     jobset_id     integer not null,
 
-    errorMsg      text, -- error output from the evaluator
-    errorTime     integer, -- timestamp associated with errorMsg
+    evaluationerror_id integer,
 
     timestamp     integer not null, -- when this entry was added
     checkoutTime  integer not null, -- how long obtaining the inputs took (in seconds)
@@ -471,7 +475,8 @@ create table JobsetEvals (
     nixExprInput  text, -- name of the jobsetInput containing the Nix or Guix expression
     nixExprPath   text, -- relative path of the Nix or Guix expression
 
-    foreign key   (jobset_id) references Jobsets(id) on delete cascade
+    foreign key   (jobset_id) references Jobsets(id) on delete cascade,
+    foreign key   (evaluationerror_id) references EvaluationErrors(id) on delete set null
 );
 
 

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -613,6 +613,8 @@ create index IndexJobsetEvalMembersOnEval on JobsetEvalMembers(eval);
 create index IndexJobsetInputAltsOnInput on JobsetInputAlts(project, jobset, input);
 create index IndexJobsetInputAltsOnJobset on JobsetInputAlts(project, jobset);
 create index IndexProjectsOnEnabled on Projects(enabled);
+create index IndexBuildOutputsPath on BuildOutputs using hash(path);
+
 
 --  For hydra-update-gc-roots.
 create index IndexBuildsOnKeep on Builds(keep) where keep = 1;

--- a/src/sql/hydra.sql
+++ b/src/sql/hydra.sql
@@ -440,6 +440,9 @@ create table JobsetEvals (
     project       text not null,
     jobset        text not null,
 
+    errorMsg      text, -- error output from the evaluator
+    errorTime     integer, -- timestamp associated with errorMsg
+
     timestamp     integer not null, -- when this entry was added
     checkoutTime  integer not null, -- how long obtaining the inputs took (in seconds)
     evalTime      integer not null, -- how long evaluation took (in seconds)

--- a/src/sql/update-dbix-harness.sh
+++ b/src/sql/update-dbix-harness.sh
@@ -1,24 +1,26 @@
 #!/usr/bin/env bash
 
+set -eux
+
 readonly scratch=$(mktemp -d -t tmp.XXXXXXXXXX)
 
 readonly socket=$scratch/socket
 readonly data=$scratch/data
 readonly dbname=hydra-update-dbix
 
-function finish {
-    set +e
-    pg_ctl -D "$data" \
-           -o "-F -h '' -k \"$socket\"" \
-           -w stop -m immediate
+function finish() {
+       set +e
+       pg_ctl -D "$data" \
+              -o "-F -h '' -k \"$socket\"" \
+              -w stop -m immediate
 
-    if [ -f "$data/postmaster.pid" ]; then
-        pg_ctl -D "$data" \
-               -o "-F -h '' -k \"$socket\"" \
-               -w kill TERM "$(cat "$data/postmaster.pid")"
-    fi
+       if [ -f "$data/postmaster.pid" ]; then
+              pg_ctl -D "$data" \
+                     -o "-F -h '' -k \"$socket\"" \
+                     -w kill TERM "$(cat "$data/postmaster.pid")"
+       fi
 
-    rm -rf "$scratch"
+       rm -rf "$scratch"
 }
 trap finish EXIT
 
@@ -33,8 +35,11 @@ pg_ctl -D "$data" \
 
 createdb -h "$socket" "$dbname"
 
-psql -h "$socket" "$dbname" -f ./hydra.sql
+psql --host "$socket" \
+       --set ON_ERROR_STOP=1 \
+       --file ./hydra.sql \
+       "$dbname"
 
 perl -I ../lib \
-     -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib \
-     update-dbix.pl "dbi:Pg:dbname=$dbname;host=$socket"
+       -MDBIx::Class::Schema::Loader=make_schema_at,dump_to_dir:../lib \
+       update-dbix.pl "dbi:Pg:dbname=$dbname;host=$socket"

--- a/src/sql/update-dbix.pl
+++ b/src/sql/update-dbix.pl
@@ -21,6 +21,7 @@ make_schema_at("Hydra::Schema", {
             "cachedhginputs" => "CachedHgInputs",
             "cachedpathinputs" => "CachedPathInputs",
             "cachedsubversioninputs" => "CachedSubversionInputs",
+            "evaluationerrors" => "EvaluationErrors",
             "failedpaths" => "FailedPaths",
             "jobsetevalinputs" => "JobsetEvalInputs",
             "jobsetevalmembers" => "JobsetEvalMembers",

--- a/src/sql/upgrade-69.sql
+++ b/src/sql/upgrade-69.sql
@@ -1,0 +1,1 @@
+create index IndexBuildOutputsPath on BuildOutputs using hash(path);

--- a/src/sql/upgrade-70.sql
+++ b/src/sql/upgrade-70.sql
@@ -1,0 +1,34 @@
+ALTER TABLE JobsetEvals
+    ADD COLUMN errorMsg text,
+    ADD COLUMN errorTime integer NULL;
+
+-- Copy the current error in jobsets to the latest field in jobsetevals
+UPDATE jobsetevals
+    SET errorMsg = j.errorMsg,
+        errorTime = j.errorTime
+  FROM (
+    SELECT
+        jobsets.errorMsg,
+        jobsets.errorTime,
+        jobsets.id AS jobset_id,
+        latesteval.id AS eval_id
+    FROM jobsets
+    LEFT JOIN
+        (
+            SELECT
+                MAX(id) AS id,
+                project,
+                jobset
+            FROM jobsetevals
+            GROUP BY project, jobset
+            ORDER BY project, jobset
+        )
+        AS latesteval
+        ON
+            jobsets.name = latesteval.jobset
+            AND jobsets.project = latesteval.project
+    WHERE latesteval.id IS NOT NULL
+    ORDER BY jobsets.id
+)
+AS j
+WHERE id = j.eval_id;

--- a/src/sql/upgrade-71.sql
+++ b/src/sql/upgrade-71.sql
@@ -1,0 +1,31 @@
+ALTER TABLE JobsetEvals
+    ADD COLUMN nixExprInput text,
+    ADD COLUMN nixExprPath text;
+
+
+-- This migration took 4.5 hours on a server
+-- with 5400RPM drives, against a copy of hydra's
+-- production dataset. It might take a significantly
+-- less amount of time there, and not justify a
+-- batched migration.
+UPDATE jobsetevals
+SET (nixexprinput, nixexprpath) = (
+    SELECT builds.nixexprinput, builds.nixexprpath
+    FROM builds
+    LEFT JOIN jobsetevalmembers
+      ON jobsetevalmembers.build = builds.id
+    WHERE jobsetevalmembers.eval = jobsetevals.id
+    LIMIT 1
+)
+WHERE jobsetevals.id in (
+  SELECT jobsetevalsprime.id
+  FROM jobsetevals as jobsetevalsprime
+  WHERE jobsetevalsprime.nixexprinput IS NULL
+  -- AND jobsetevalsprime.id > ? --------- These are in case of a batched migration
+  ORDER BY jobsetevalsprime.id ASC  --  /
+  -- LIMIT ?  --  ----------------------
+);
+
+ALTER TABLE builds
+    DROP COLUMN nixexprinput,
+    DROP COLUMN nixexprpath;

--- a/src/sql/upgrade-72.sql
+++ b/src/sql/upgrade-72.sql
@@ -1,0 +1,22 @@
+
+ALTER TABLE JobsetEvals
+  ADD COLUMN jobset_id integer NULL,
+  ADD FOREIGN KEY (jobset_id)
+      REFERENCES Jobsets(id)
+      ON DELETE CASCADE;
+
+UPDATE JobsetEvals
+  SET jobset_id = (
+    SELECT jobsets.id
+    FROM jobsets
+    WHERE jobsets.name = JobsetEvals.jobset
+      AND jobsets.project = JobsetEvals.project
+  );
+
+
+ALTER TABLE JobsetEvals
+  ALTER COLUMN jobset_id SET NOT NULL,
+  DROP COLUMN jobset,
+  DROP COLUMN project;
+
+create index IndexJobsetIdEvals on JobsetEvals(jobset_id) where hasNewBuilds = 1;

--- a/src/sql/upgrade-73.sql
+++ b/src/sql/upgrade-73.sql
@@ -1,0 +1,35 @@
+create table EvaluationErrors (
+    id            serial primary key not null,
+    errorMsg      text,    -- error output from the evaluator
+    errorTime     integer, -- timestamp associated with errorMsg
+    jobsetEvalId  integer not null,
+
+    FOREIGN KEY (jobsetEvalId)
+        REFERENCES JobsetEvals(id)
+        ON DELETE SET NULL
+);
+
+ALTER TABLE JobsetEvals
+    ADD COLUMN evaluationerror_id integer NULL,
+    ADD FOREIGN KEY (evaluationerror_id)
+        REFERENCES EvaluationErrors(id)
+        ON DELETE SET NULL;
+
+INSERT INTO EvaluationErrors
+    (errorMsg, errorTime, jobsetEvalId)
+SELECT errorMsg, errorTime, id
+FROM JobsetEvals
+WHERE JobsetEvals.errorMsg != '' and JobsetEvals.errorMsg is not null;
+
+UPDATE JobsetEvals
+SET evaluationerror_id = EvaluationErrors.id
+FROM EvaluationErrors
+WHERE JobsetEvals.id = EvaluationErrors.jobsetEvalId
+AND JobsetEvals.errorMsg != '' and JobsetEvals.errorMsg is not null;
+
+ALTER TABLE JobsetEvals
+    DROP COLUMN errorMsg,
+    DROP COLUMN errorTime;
+
+ALTER TABLE EvaluationErrors
+    DROP COLUMN jobsetEvalId;

--- a/src/sql/upgrade-74.sql
+++ b/src/sql/upgrade-74.sql
@@ -1,0 +1,9 @@
+alter table Jobsets add constraint jobsets_type_known_check   check (type = 0 or type = 1);
+alter table Jobsets add constraint jobsets_legacy_paths_check check ((type = 0) = (nixExprInput is not null and nixExprPath is not null and flake is     null));
+alter table Jobsets add constraint jobsets_flake_paths_check  check ((type = 1) = (nixExprInput is     null and nixExprPath is     null and flake is not null));
+alter table Jobsets add constraint jobsets_schedulingshares_nonzero_check check (schedulingShares > 0);
+
+alter table Jobsets drop constraint if exists jobsets_schedulingshares_check;
+alter table Jobsets drop constraint if exists jobsets_check;
+alter table Jobsets drop constraint if exists jobsets_check1;
+alter table Jobsets drop constraint if exists jobsets_check2;

--- a/tests/set-up.pl
+++ b/tests/set-up.pl
@@ -1,5 +1,5 @@
 use strict;
-system("initdb -D postgres") == 0 or die;
-system("pg_ctl -D postgres -o \"-F -p 6433 -h '' -k /tmp \" -w start") == 0 or die;
-system("createdb -p 6433 hydra-test-suite") == 0 or die;
+system("initdb -D postgres --locale C.UTF-8 ") == 0 or die;
+system("pg_ctl -D postgres -o \"-F -p 6433  -h '' -k /tmp \" -w start") == 0 or die;
+system("createdb -l C.UTF-8 -p 6433 hydra-test-suite") == 0 or die;
 system("hydra-init") == 0 or die;


### PR DESCRIPTION
Fix the build to adjust to some breaking changes in Nix master:

- `string2Int` now has a slightly different signature
- The `printHelp` function doesn't exist anymore.

Note that this removes the `--help` of `hydra-eval-jobs`.
That doesn't seem too bad given that most hydra commands don't have such a flag, but ideally we should probably migrate it to use the same autogenerated manpages as Nix now uses.
